### PR TITLE
Update issue templates for InVEST models and SER

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-invest-model.md
+++ b/.github/ISSUE_TEMPLATE/new-invest-model.md
@@ -1,0 +1,18 @@
+---
+name: New InVEST Model
+about: When there's a new InVEST model in the works
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- describe any context about this model here -->
+
+## Design Document
+
+<!-- Is there a design document available?  If not, note that.  Otherwise, provide the link. -->
+
+## PSC Approval Status
+
+<!-- Note the status of the PSC's approval.  If this hasn't yet gone through the PSC, note that. -->

--- a/.github/ISSUE_TEMPLATE/software-engagement-request.md
+++ b/.github/ISSUE_TEMPLATE/software-engagement-request.md
@@ -1,0 +1,39 @@
+---
+name: Software Engagement Request
+about: Requesting nontrivial help from the software team
+title: ''
+labels: SER
+assignees: ''
+
+---
+
+## Deliverables
+
+What work is being requested of the software team?  If you have a design document, please include that link here.
+
+
+## Motivation/Justification/Statement of Impact
+
+Who will benefit from this work and to what degree?
+
+
+## Timelines
+
+Are there any timelines (real timelines only, please) that the software team should know about?
+
+
+## Anything else we should know about?
+
+Please provide any other information that the software team should know about.
+
+## Primary Contacts
+
+Who on the science team should the software team contact about this request?
+
+---
+
+<!-- Software Team completes the below information -->
+## Software Team Section
+
+- [ ] Roughly how long is the requested work estimated to take given the above scope?
+- [ ] Given current team priorities, when might the team be able to take this on?


### PR DESCRIPTION
This PR updates adds 2 new issue templates for tracking information in the softwareteam issue tracker:

* **New InVEST Model** for when there's a new InVEST model in development that we'd like to keep on our radar.
* **Software Engagement Request** for when a science team has a nontrivial request of our time, like for help on a project.  Minor issues (help with a `pandas` question, for example) might just be able to be addressed without going through the issue tracker.

FYI, this whole repo should be writeable for all of us, so please feel free to edit the templates directly if you like!